### PR TITLE
refactor: use library asgi-matomo

### DIFF
--- a/karp-backend/pyproject.toml
+++ b/karp-backend/pyproject.toml
@@ -42,6 +42,7 @@ typer = "^0.7.0"
 ulid-py = "^1.1.0"
 urllib3 = "^1.26.13"
 karp-lex-core = ">=0.5.1"
+asgi-matomo = "^0.1.0"
 
 [tool.poetry.scripts]
 karp-cli = "karp.cliapp.main:cliapp"
@@ -71,7 +72,7 @@ mkdocstrings = "^0.19.0"
 mkdocstrings-python = "^0.7.1"
 types-factory-boy = "^0.3.1"
 types-deprecated = "^1.2.9"
-httpx = "^0.23.1"
+httpx = "^0.24.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/karp-backend/src/karp/karp_v6_api/main.py
+++ b/karp-backend/src/karp/karp_v6_api/main.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 import logging  # noqa: F811
 from asgi_correlation_id import CorrelationIdMiddleware
 from asgi_correlation_id.context import correlation_id
+from asgi_matomo import MatomoMiddleware
 
 from karp import main
 from karp.foundation import errors as foundation_errors
@@ -31,7 +32,6 @@ from karp.main.errors import ClientErrorCodes
 from karp.main import modules, config
 from karp.karp_v6_api.routes import router as api_router
 from karp.karp_v6_api import tasks
-from karp.karp_v6_api.contrib import MatomoMiddleware
 
 
 querying_description = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ tqdm = "^4.64.1"
 typer = "^0.7.0"
 ulid-py = "^1.1.0"
 urllib3 = "^1.26.13"
+asgi-matomo = "^0.1.0"
 
 [tool.poetry.extras]
 mysql = ["mysqlclient", "PyMySQL", "aiomysql"]
@@ -95,7 +96,7 @@ mkdocstrings = "^0.19.0"
 mkdocstrings-python = "^0.7.1"
 types-factory-boy = "^0.3.1"
 types-deprecated = "^1.2.9"
-httpx = "^0.23.1"
+httpx = "^0.24.0"
 ruff = "^0.0.243"
 
 [tool.vulture]


### PR DESCRIPTION
Uses library `asgi-matomo` that is extracted from 
karp-backend/src/karp/karp_v6_api/contrib/matomo.py and adapted to be a bit
more general.

