### PR TITLE
feat(cli): add 'entries batch' command

### DIFF
--- a/karp-backend/src/karp/cliapp/main.py
+++ b/karp-backend/src/karp/cliapp/main.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_app():  # noqa: ANN201, D103
-    app = typer.Typer(help="Karp CLI")
+    app = typer.Typer(help="Karp CLI", rich_markup_mode="markdown")
     app_context = bootstrap_app()
 
     @app.callback()

--- a/karp-backend/src/karp/cliapp/subapps/entries_subapp.py
+++ b/karp-backend/src/karp/cliapp/subapps/entries_subapp.py
@@ -37,7 +37,7 @@ def add_entries_to_resource(  # noqa: ANN201, D103
     user: Optional[str] = typer.Option(None),
     message: Optional[str] = typer.Option(None),
 ):
-    bus = inject_from_ctx(CommandBus, ctx)
+    bus = inject_from_ctx(CommandBus, ctx)  # type: ignore[type-abstract]
     user = user or "local admin"
     message = message or "imported through cli"
     entries = tqdm(json_streams.load_from_file(data), desc="Adding", unit=" entries")
@@ -50,7 +50,7 @@ def add_entries_to_resource(  # noqa: ANN201, D103
             message=message,
         )
     else:
-        cmd = lex.AddEntries(
+        cmd = lex.AddEntries(  # type: ignore[assignment]
             resourceId=resource_id,
             entries=entries,
             user=user,
@@ -72,10 +72,10 @@ def import_entries_to_resource(  # noqa: ANN201, D103
     user: Optional[str] = typer.Option(None),
     message: Optional[str] = typer.Option(None),
 ):
-    bus = inject_from_ctx(CommandBus, ctx)
+    bus = inject_from_ctx(CommandBus, ctx)  # type: ignore[type-abstract]
     user = user or "local admin"
     message = message or "imported through cli"
-    entries = tqdm(json_streams.load_from_file(data), desc="Adding", unit=" entries")
+    entries = tqdm(json_streams.load_from_file(data), desc="Importing", unit=" entries")
     if chunked:
         cmd = lex.ImportEntriesInChunks(
             resourceId=resource_id,
@@ -85,7 +85,7 @@ def import_entries_to_resource(  # noqa: ANN201, D103
             message=message,
         )
     else:
-        cmd = lex.ImportEntries(
+        cmd = lex.ImportEntries(  # type: ignore[assignment]
             resourceId=resource_id,
             entries=entries,
             user=user,
@@ -110,7 +110,7 @@ def export_entries(  # noqa: ANN201, D103
     resource_id: str,
     output: typer.FileBinaryWrite = typer.Option(..., "--output", "-o"),
 ):
-    entry_views = inject_from_ctx(lex.EntryViews, ctx=ctx)
+    entry_views = inject_from_ctx(lex.EntryViews, ctx=ctx)  # type: ignore[type-abstract]
     all_entries = entry_views.all_entries(resource_id=resource_id)
     logger.debug(
         "exporting entries",

--- a/karp-backend/src/karp/lex/__init__.py
+++ b/karp-backend/src/karp/lex/__init__.py
@@ -1,6 +1,6 @@
 import injector  # noqa: I001
 
-from karp.command_bus import CommandHandler
+from karp.command_bus import CommandBus, CommandHandler
 from karp.lex.application.repositories import (
     EntryUowRepositoryUnitOfWork,
     EntryRepositoryUnitOfWorkFactory,
@@ -16,6 +16,8 @@ from karp.lex_core.commands import (
     ImportEntries,
     ImportEntriesInChunks,
     SetEntryRepoId,
+    EntryCommand,
+    ExecuteBatchOfEntryCommands,
 )
 from karp.lex_core import commands
 from karp.lex.domain.value_objects import EntrySchema
@@ -31,6 +33,7 @@ from karp.lex.application.use_cases import (
     SettingEntryRepoId,
     UpdatingEntry,
     UpdatingResource,
+    ExecutingBatchOfEntryCommands,
 )
 from karp.lex.application.queries import (
     EntryDto,
@@ -54,13 +57,14 @@ __all__ = [
     # modules
     "commands",
     # commands
-    "commands",
     "AddEntries",
     "AddEntriesInChunks",
     "AddEntry",
     "ImportEntries",
     "ImportEntriesInChunks",
     "CreateEntryRepository",
+    "EntryCommand",
+    "ExecuteBatchOfEntryCommands",
     # use cases
     "CreatingEntryRepo",
     "CreatingResource",
@@ -164,7 +168,7 @@ class Lex(injector.Module):  # noqa: D101
         resource_uow: ResourceUnitOfWork,
         entry_repo_uow: EntryUowRepositoryUnitOfWork,
     ) -> CommandHandler[AddEntriesInChunks]:
-        return AddingEntries(resource_uow=resource_uow, entry_repo_uow=entry_repo_uow)
+        return AddingEntries(resource_uow=resource_uow, entry_repo_uow=entry_repo_uow)  # type: ignore[return-value]
 
     @injector.provider
     def import_entries(  # noqa: D102
@@ -182,7 +186,7 @@ class Lex(injector.Module):  # noqa: D101
         resource_uow: ResourceUnitOfWork,
         entry_repo_uow: EntryUowRepositoryUnitOfWork,
     ) -> CommandHandler[ImportEntriesInChunks]:
-        return ImportingEntries(
+        return ImportingEntries(  # type: ignore[return-value]
             resource_uow=resource_uow, entry_repo_uow=entry_repo_uow
         )
 
@@ -204,3 +208,10 @@ class Lex(injector.Module):  # noqa: D101
         entry_repo_uow: EntryUowRepositoryUnitOfWork,
     ) -> CommandHandler[commands.DeleteEntry]:
         return DeletingEntry(resource_uow=resource_uow, entry_repo_uow=entry_repo_uow)
+
+    @injector.provider
+    def batch_of_entry_commands(
+        self,
+        command_bus: CommandBus,
+    ) -> CommandHandler[commands.ExecuteBatchOfEntryCommands]:
+        return ExecutingBatchOfEntryCommands(command_bus=command_bus)

--- a/karp-backend/src/karp/lex/application/use_cases/__init__.py
+++ b/karp-backend/src/karp/lex/application/use_cases/__init__.py
@@ -4,6 +4,7 @@ from .entry_handlers import (  # noqa: I001
     DeletingEntry,
     ImportingEntries,
     UpdatingEntry,
+    ExecutingBatchOfEntryCommands,
 )
 from .entry_repo_handlers import (
     CreatingEntryRepo,
@@ -24,6 +25,7 @@ __all__ = [
     "DeletingEntry",
     "ImportingEntries",
     "UpdatingEntry",
+    "ExecutingBatchOfEntryCommands",
     # entry-repo use cases
     "CreatingEntryRepo",
     # resource use cases

--- a/karp-backend/src/karp/lex/application/use_cases/entry_handlers.py
+++ b/karp-backend/src/karp/lex/application/use_cases/entry_handlers.py
@@ -1,7 +1,8 @@
 """Handling of entry commands."""
 import logging
+from typing import Any
 
-from karp.command_bus import CommandHandler
+from karp.command_bus import CommandBus, CommandHandler
 from karp.lex.application import repositories
 from karp.lex.application.repositories import EntryUnitOfWork
 from karp.lex.domain import errors
@@ -230,3 +231,14 @@ class DeletingEntry(BaseEntryHandler, CommandHandler[commands.DeleteEntry]):
             uw.repo.save(entry)
             uw.post_on_commit(events)
             uw.commit()
+
+
+class ExecutingBatchOfEntryCommands(
+    CommandHandler[commands.ExecuteBatchOfEntryCommands]
+):
+    def __init__(self, command_bus: CommandBus) -> None:
+        self.command_bus = command_bus
+
+    def execute(self, command: commands.ExecuteBatchOfEntryCommands) -> Any:
+        for cmd in command.commands:
+            self.command_bus.dispatch(cmd.cmd)

--- a/karp-lex-core/src/karp/lex_core/commands/__init__.py
+++ b/karp-lex-core/src/karp/lex_core/commands/__init__.py
@@ -5,6 +5,7 @@ from .entry_commands import (
     AddEntry,
     DeleteEntry,
     EntryCommand,
+    ExecuteBatchOfEntryCommands,
     GenericAddEntry,
     GenericUpdateEntry,
     ImportEntries,
@@ -34,6 +35,7 @@ __all__ = [
     "ImportEntriesInChunks",
     "UpdateEntry",
     "EntryCommand",
+    "ExecuteBatchOfEntryCommands",
     # EntryRepo commands
     "CreateEntryRepository",
     # Resource commands

--- a/karp-lex-core/src/karp/lex_core/commands/__init__.py
+++ b/karp-lex-core/src/karp/lex_core/commands/__init__.py
@@ -4,6 +4,7 @@ from .entry_commands import (
     AddEntriesInChunks,
     AddEntry,
     DeleteEntry,
+    EntryCommand,
     GenericAddEntry,
     GenericUpdateEntry,
     ImportEntries,
@@ -32,6 +33,7 @@ __all__ = [
     "ImportEntries",
     "ImportEntriesInChunks",
     "UpdateEntry",
+    "EntryCommand",
     # EntryRepo commands
     "CreateEntryRepository",
     # Resource commands

--- a/karp-lex-core/src/karp/lex_core/commands/entry_commands.py
+++ b/karp-lex-core/src/karp/lex_core/commands/entry_commands.py
@@ -77,3 +77,7 @@ EntryCommandType = Annotated[
 
 class EntryCommand(pydantic.BaseModel):
     cmd: EntryCommandType
+
+
+class ExecuteBatchOfEntryCommands(pydantic.BaseModel):
+    commands: Iterable[EntryCommand]

--- a/karp-lex-core/src/karp/lex_core/commands/entry_commands.py
+++ b/karp-lex-core/src/karp/lex_core/commands/entry_commands.py
@@ -1,4 +1,12 @@
-from typing import Generic, Iterable, Literal, Optional, TypeVar  # noqa: D100
+from typing import (
+    Annotated,
+    Generic,
+    Iterable,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)  # noqa: D100
 
 import pydantic
 from karp.lex_core.value_objects import UniqueId, make_unique_id
@@ -60,3 +68,12 @@ class GenericUpdateEntry(GenericModel, Generic[T], Command):  # noqa: D101
 
 class UpdateEntry(GenericUpdateEntry[dict]):  # noqa: D101
     ...
+
+
+EntryCommandType = Annotated[
+    Union[AddEntry, DeleteEntry, UpdateEntry], pydantic.Field(discriminator="cmdtype")
+]
+
+
+class EntryCommand(pydantic.BaseModel):
+    cmd: EntryCommandType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ tqdm = "^4.64.1"
 typer = "^0.7.0"
 ulid-py = "^1.1.0"
 urllib3 = "^1.26.13"
+rich = "^13.3.5"
 
 [tool.poetry.extras]
 mysql = ["mysqlclient", "PyMySQL", "aiomysql"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,3 +25,4 @@ exclude = [
 [per-file-ignores]
 "__init__.py" = ["E402"]
 "bases/karp/karp_v6_api/routes/resources_api.py" = ["B008"]
+"tests/*" = ["S101"]

--- a/tests/unit/lex_core/test_entry_commands.py
+++ b/tests/unit/lex_core/test_entry_commands.py
@@ -1,0 +1,52 @@
+from karp.lex_core.commands import AddEntry, DeleteEntry, EntryCommand, UpdateEntry
+from karp.lex_core.value_objects import make_unique_id
+
+
+class TestDeserializeEntryCommand:
+    def test_can_deserialize_add_entry(self) -> None:
+        data = {
+            "cmd": {
+                "cmdtype": "add_entry",
+                "resourceId": "resource_a",
+                "entry": {"baseform": "sko"},
+                "message": "add sko",
+                "user": "alice@example.com",
+            }
+        }
+
+        cmd = EntryCommand(**data)
+
+        assert isinstance(cmd.cmd, AddEntry)
+
+    def test_can_deserialize_delete_entry(self) -> None:
+        data = {
+            "cmd": {
+                "cmdtype": "delete_entry",
+                "resourceId": "resource_a",
+                "id": make_unique_id(),
+                "version": 1,
+                "message": "add sko",
+                "user": "alice@example.com",
+            }
+        }
+
+        cmd = EntryCommand(**data)
+
+        assert isinstance(cmd.cmd, DeleteEntry)
+
+    def test_can_deserialize_update_entry(self) -> None:
+        data = {
+            "cmd": {
+                "cmdtype": "update_entry",
+                "resourceId": "resource_a",
+                "id": make_unique_id(),
+                "entry": {"baseform": "sko"},
+                "version": 1,
+                "message": "add sko",
+                "user": "alice@example.com",
+            }
+        }
+
+        cmd = EntryCommand(**data)
+
+        assert isinstance(cmd.cmd, UpdateEntry)


### PR DESCRIPTION
Allows a batch of entry commands be executed through the CLI with `karp-cli entries batch <PATH>`

Example of json (can also be jsonl, json.gz or jsonl.gz)
```json
[
    {
        "cmd": {
            "cmdtype": "add_entry",
            "resourceId": "resource_a",
            "entry": {
                "baseform": "sko"
            },
            "message": "add sko",
            "user": "alice@example.com"
        }
    },
    {
        "cmd": {
            "cmdtype": "delete_entry",
            "resourceId": "resource_a",
            "id": "01BJQMF54D093DXEAWZ6JYRPAQ",
            "version": 1,
            "message": "delete lada",
            "user": "bob@example.com"
        }
    },
    {
        "cmd": {
            "cmdtype": "update_entry",
            "resourceId": "resource_a",
            "id": "01BJQMF54D093DXEAWZ6JYRPAT",
            "entry": {
                "baseform": "klot"
            },
            "version": 3,
            "message": "update klot",
            "user": "alice@example.com"
        }
    }
]
```
